### PR TITLE
fix: ensure assets load correctly on Kubernetes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "cardapio-frontend",
   "version": "1.0.0",
   "private": true,
+  "homepage": ".",
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,8 +1,15 @@
 import axios from 'axios';
 
+// Use a base URL defined at build time via REACT_APP_API_BASE_URL.
+// When the variable is not provided (e.g. in Kubernetes where the
+// frontend is served behind an ingress), fall back to the current
+// origin with a standard `/api` prefix. This allows the same build to
+// work locally, in Docker, and in Kubernetes without needing to rebuild
+// the frontend for each environment.
+const baseURL = process.env.REACT_APP_API_BASE_URL || `${window.location.origin}/api`;
+
 const api = axios.create({
-  //baseURL: 'http://localhost:4000/api',
-  baseURL: process.env.REACT_APP_API_BASE_URL,  // usa a env var
+  baseURL,
 });
 
 // Adicionar interceptor para incluir token de autenticação


### PR DESCRIPTION
## Summary
- use runtime origin for API base URL when `REACT_APP_API_BASE_URL` is unset
- make CRA build emit relative asset paths so CSS loads under subpaths

## Testing
- `bash build-and-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896543cd0e48326babbb09206057396