### PR TITLE
fix: ensure assets load correctly on Kubernetes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "cardapio-frontend",
   "version": "1.0.0",
   "private": true,
+  "homepage": ".",
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,8 +1,17 @@
 import axios from 'axios';
 
+// Use a base URL defined at build time via REACT_APP_API_BASE_URL.
+// When the variable is not provided (e.g. in Kubernetes where the
+// frontend is served behind an ingress), fall back to a path relative
+// to the application's first URL segment. This ensures API calls resolve
+// correctly when the app is deployed under a subpath like `/cardapio`.
+const [, firstSegment] = window.location.pathname.split('/');
+const apiBasePath = firstSegment ? `/${firstSegment}/api` : '/api';
+const baseURL =
+  process.env.REACT_APP_API_BASE_URL || `${window.location.origin}${apiBasePath}`;
+
 const api = axios.create({
-  //baseURL: 'http://localhost:4000/api',
-  baseURL: process.env.REACT_APP_API_BASE_URL,  // usa a env var
+  baseURL,
 });
 
 // Adicionar interceptor para incluir token de autenticação


### PR DESCRIPTION
## Summary
- use runtime origin for API base URL when `REACT_APP_API_BASE_URL` is unset
- make CRA build emit relative asset paths so CSS loads under subpaths
- compute API path from first URL segment to handle subpath deployments

## Testing
- `bash build-and-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896543cd0e48326babbb09206057396